### PR TITLE
Volatile memory support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,13 @@
 # Changelog
 All notable changes to this project will be documented in this file.
 
+## [0.1.14-SNAPSHOT] - 2023-02-01
+
+### Changed
+
+ - Multipart message library upgrade from 1.0.14-SNAPSHOT to 1.0.15-SNAPSHOT (memory cleaner in MMP)
+ - WebSocket Message Streamer library upgrade from 1.0.15-SNAPSHOT to 1.0.16-SNAPSHOT (memory cleaner in MMP)
+
 ## [0.1.13-SNAPSHOT] - 2022-12-22
 
 ### Notes

--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
 	</parent>
 	<groupId>it.eng.idsa</groupId>
 	<artifactId>market4.0-data-app</artifactId>
-	<version>0.1.13-SNAPSHOT</version>
+	<version>0.1.14-SNAPSHOT</version>
 	<name>market4.0-data-app</name>
 	<description>The project for market4.0-data-app</description>
 
@@ -20,8 +20,8 @@
 		<tomcat.version>9.0.27</tomcat.version>
 		<start-class>it.eng.idsa.dataapp.ApplicationDataApp</start-class>
 		<information.model.version>4.1.1</information.model.version>
-		<multipart.message.processor.version>1.0.14-SNAPSHOT</multipart.message.processor.version>
-		<websocket.message.streamer.version>1.0.15-SNAPSHOT</websocket.message.streamer.version>
+		<multipart.message.processor.version>1.0.15-SNAPSHOT</multipart.message.processor.version>
+		<websocket.message.streamer.version>1.0.16-SNAPSHOT</websocket.message.streamer.version>
 	</properties>
 
 	<repositories>


### PR DESCRIPTION
 - Multipart message library upgrade from 1.0.14-SNAPSHOT to 1.0.15-SNAPSHOT (memory cleaner in MMP)
 - WebSocket Message Streamer library upgrade from 1.0.15-SNAPSHOT to 1.0.16-SNAPSHOT (memory cleaner in MMP)